### PR TITLE
Show custom chords from the editor with the define statement.

### DIFF
--- a/Chord Provider.xcodeproj/project.pbxproj
+++ b/Chord Provider.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2B5142AC28FEB9BA00C61C4E /* ChordPostion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5142AB28FEB9BA00C61C4E /* ChordPostion.swift */; };
+		2B5142AD28FEB9BA00C61C4E /* ChordPostion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5142AB28FEB9BA00C61C4E /* ChordPostion.swift */; };
 		D70D719C28C6055F00AF0022 /* Debouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70D719B28C6055F00AF0022 /* Debouncer.swift */; };
 		D70D719D28C6055F00AF0022 /* Debouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70D719B28C6055F00AF0022 /* Debouncer.swift */; };
 		D70D71AC28C75B7100AF0022 /* Editor+format.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70D71AB28C75B7100AF0022 /* Editor+format.swift */; };
@@ -107,6 +109,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2B5142AB28FEB9BA00C61C4E /* ChordPostion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChordPostion.swift; sourceTree = "<group>"; };
 		D70D719B28C6055F00AF0022 /* Debouncer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debouncer.swift; sourceTree = "<group>"; };
 		D70D71AB28C75B7100AF0022 /* Editor+format.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Editor+format.swift"; sourceTree = "<group>"; };
 		D70D71AD28C75C3600AF0022 /* Editor+Directive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Editor+Directive.swift"; sourceTree = "<group>"; };
@@ -290,6 +293,7 @@
 			isa = PBXGroup;
 			children = (
 				D70D71AF28C760C300AF0022 /* String.swift */,
+				2B5142AB28FEB9BA00C61C4E /* ChordPostion.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -514,6 +518,7 @@
 				D771675728F35F3800F5DEB2 /* String.swift in Sources */,
 				D7B701002577A8E3005AEBF6 /* HeaderView.swift in Sources */,
 				D759296B25723025006DDF24 /* Line.swift in Sources */,
+				2B5142AD28FEB9BA00C61C4E /* ChordPostion.swift in Sources */,
 				D734A0B025F93208007AB36A /* ChordsView.swift in Sources */,
 				D759294A2572280C006DDF24 /* ChordProDocument.swift in Sources */,
 			);
@@ -528,6 +533,7 @@
 				D70D71AC28C75B7100AF0022 /* Editor+format.swift in Sources */,
 				D7BA2B312584FD5E006C272E /* FileBrowserView.swift in Sources */,
 				D771675928F46D4200F5DEB2 /* Editor.swift in Sources */,
+				2B5142AC28FEB9BA00C61C4E /* ChordPostion.swift in Sources */,
 				D759296825723025006DDF24 /* Section.swift in Sources */,
 				D7CC570F25FBAFC700AD96CA /* Chord.swift in Sources */,
 				D7667D8E273FD042002E7DF9 /* FileBrowser.swift in Sources */,

--- a/Chord Provider/Extensions/ChordPostion.swift
+++ b/Chord Provider/Extensions/ChordPostion.swift
@@ -1,0 +1,87 @@
+//
+//  ChordPostions.swift
+//  Chord Provider
+//
+//  Created by Sascha Müller zum Hagen on 18.10.22.
+//
+
+import Foundation
+import SwiftyChords
+
+extension ChordPosition {
+    
+    /// Create a ChordPosition element from a string whcih defines the Chord with a ChordPro layout.
+    ///  For mor information about the layout, have a look at https://www.chordpro.org/chordpro/directives-define/
+    /// - Parameter define: ChordPro string definition of the chord.
+    init(from define: String) throws {
+        // The base implementation of ChordPostion only implements a decoder.
+        // Use a 'C major' as base to define th e new chord from.
+        // The SwiftyChords.ChordPostion does not allow to use any custom chords, because the key, and suffix are enum types.
+        var baseFret: Int = 1
+        var frets: [Int] = [0, 0, 0, 0, 0, 0]
+        var fingers: [Int] = [0, 0, 0, 0, 0, 0]
+        var barres: [Int] = []
+
+        // try to get the chord out of the string without the finger position.
+        // swiftlint:disable:next operator_usage_whitespace
+        let regexBase = /base-fret(?<baseFret>[\s1-9]+)frets(?<frets>[\soOxXN0-9]+)(?<last>.*)/
+        if let resultBase = try? regexBase.wholeMatch(in: define) {
+            
+            if let conv = Int(String(resultBase.baseFret).trimmingCharacters(in: .whitespacesAndNewlines)) {
+                baseFret = conv
+            }
+            
+            var fretsString = String(resultBase.frets).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !fretsString.isEmpty {
+                fretsString = fretsString.replacingOccurrences(of: "[xX]", with: "-1", options: .regularExpression, range: nil)
+                fretsString = fretsString.replacingOccurrences(of: "[oON]", with: "0", options: .regularExpression, range: nil)
+                
+                var fretsArr = fretsString.components(separatedBy: .whitespacesAndNewlines)
+                fretsArr = fretsArr.filter { !$0.isEmpty }
+                frets = fretsArr.map { Int($0)! }
+                
+                // append elements to have at least 6. This is needed to prevent a system failure.
+                while frets.count < 6 { frets.append(0) }
+            }
+            
+            // now try to get the finger postions.
+            // swiftlint:disable:next operator_usage_whitespace
+            let regexFingers = /fingers(?<fingers>[\s\-xXN0-9]+)(?<last>.*)/
+            if let resultFingers = try? regexFingers.wholeMatch(in: resultBase.last) {
+
+                var fingersString = String(resultFingers.fingers).trimmingCharacters(in: .whitespacesAndNewlines)
+                if !fingersString.isEmpty {
+                    fingersString = fingersString.replacingOccurrences(of: "[xXN-]", with: "0", options: .regularExpression, range: nil)
+                    
+                    var fingerArr = fingersString.components(separatedBy: .whitespacesAndNewlines)
+                    fingerArr = fingerArr.filter { !$0.isEmpty }
+                    fingers = fingerArr.map { Int($0)! }
+                    
+                    // append elements to have at least 6. This is needed to prevent a system failure.
+                    while fingers.count < 6 { fingers.append(0) }
+
+                    // set the barres but use not '0' as barres.
+                    let mappedItems = fingers.map { ($0, 1) }
+                    let counts = Dictionary(mappedItems, uniquingKeysWith: +)
+                    for (key, value) in counts where value > 1 && key != 0 {
+                        barres.append(key)
+                    }
+                }
+            }
+        }
+        
+        let data = """
+    {
+        "key": "C",
+        "suffix": "major",
+        "midi": [48, 52, 55, 60, 64],
+        "baseFret": \(baseFret),
+        "frets": \(frets),
+        "fingers": \(fingers),
+        "barres": \(barres)
+    }
+"""
+        let decoder = JSONDecoder()
+        self = try decoder.decode(ChordPosition.self, from: data.data(using: .utf8)!)
+    }
+}

--- a/Chord Provider/Parser/Chord.swift
+++ b/Chord Provider/Parser/Chord.swift
@@ -14,22 +14,23 @@ extension Song {
     struct Chord: Identifiable {
         var id = UUID()
         var name: String
-        var key: SwiftyChords.Chords.Key
-        var suffix: SwiftyChords.Chords.Suffix
-        var define: String
-        var basefret: Int {
-            return Int(define.prefix(1)) ?? 1
-        }
+        var chordPosition: ChordPosition
+        var isCustom: Bool
+        
         /// Display name for the chord
         var display: String {
-            var text = key.display.symbol
-            switch self.suffix {
-            case .major:
-                break
-            default:
-                text += suffix.display.symbolized
+            if isCustom {
+                return name
+            } else {
+                var text = chordPosition.key.display.symbol
+                switch chordPosition.suffix {
+                case .major:
+                    break
+                default:
+                    text += chordPosition.suffix.display.symbolized
+                }
+                return text
             }
-            return text
         }
     }
 }

--- a/Chord Provider/SharedViews/ChordsView.swift
+++ b/Chord Provider/SharedViews/ChordsView.swift
@@ -22,7 +22,8 @@ struct ChordsView: View {
                 ForEach(song.chords.sorted { $0.name < $1.name }) { chord in
                     Group {
                         Text("\(chord.display)").foregroundColor(.accentColor).font(.title2)
-                        let layer = chord.chordPosition.shapeLayer(rect: frame, showFingers: true, showChordName: false)
+                        let showFingers = !chord.chordPosition.fingers.dropFirst().allSatisfy({ $0 == chord.chordPosition.fingers.first })
+                        let layer = chord.chordPosition.shapeLayer(rect: frame, showFingers: showFingers, showChordName: false)
                         if let image = layer.image() {
 #if os(macOS)
                             Image(nsImage: image)

--- a/Chord Provider/SharedViews/ChordsView.swift
+++ b/Chord Provider/SharedViews/ChordsView.swift
@@ -22,23 +22,21 @@ struct ChordsView: View {
                 ForEach(song.chords.sorted { $0.name < $1.name }) { chord in
                     Group {
                         Text("\(chord.display)").foregroundColor(.accentColor).font(.title2)
-                        if let chordPosition = Chords.guitar.filter { $0.key == chord.key && $0.suffix == chord.suffix && $0.baseFret == chord.basefret} {
-                            let layer = chordPosition.first?.shapeLayer(rect: frame, showFingers: true, showChordName: false)
-                            if let image = layer?.image() {
+                        let layer = chord.chordPosition.shapeLayer(rect: frame, showFingers: true, showChordName: false)
+                        if let image = layer.image() {
 #if os(macOS)
-                                Image(nsImage: image)
+                            Image(nsImage: image)
 #endif
 #if os(iOS)
-                                Image(uiImage: image)
+                            Image(uiImage: image)
 #endif
-                            } else {
-                                VStack {
-                                    Image(systemName: "music.note")
-                                    Text("Unknown chord")
-                                }
-                                .frame(width: 100, alignment: .center)
-                                .padding(.vertical)
+                        } else {
+                            VStack {
+                                Image(systemName: "music.note")
+                                Text("Unknown chord")
                             }
+                            .frame(width: 100, alignment: .center)
+                            .padding(.vertical)
                         }
                     }
                     .onTapGesture {
@@ -63,7 +61,7 @@ extension ChordsView {
         @Environment(\.presentationMode) var presentationMode
         @Binding var chord: Song.Chord?
         var body: some View {
-            let chordPosition = SwiftyChords.Chords.guitar.matching(key: chord!.key).matching(suffix: chord!.suffix)
+            let chordPosition = SwiftyChords.Chords.guitar.matching(key: chord!.chordPosition.key).matching(suffix: chord!.chordPosition.suffix)
             VStack {
                 Text("Chord: \(chord!.display)")
                     .font(.title)


### PR DESCRIPTION
With this implementation, the chords that can be defined in the editor are also displayed correctly.
Unfortunately, a small modification had to be made to the self-defined chord. The chords are no longer recognized by their key and suffix but stored directly in it.
Afterwards the class ChordPosition of SwiftyChords could be extended by a new constructor which also allows own chords.
Finally the view was extended so that only chords with finger definition are displayed if they are present. 
