### PR TITLE
Fix not building with latest version of Adwaita for Swift

### DIFF
--- a/ChordProviderGnome/Package.swift
+++ b/ChordProviderGnome/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 /// The dependencies.
 var dependencies: [Package.Dependency] = [
 	.package(
-            url: "https://git.aparoksha.dev/desbeers/adwaita-swift-gnome-50",
+            url: "https://git.aparoksha.dev/aparoksha/adwaita-swift",
             branch: "main",
             traits: ["exposeGeneratedAppearUpdateFunctions"],
     ),
@@ -34,7 +34,7 @@ let package = Package(
         .target(
             name: "SourceView",
             dependencies: [
-                .product(name: "Adwaita", package: "adwaita-swift-gnome-50"),
+                .product(name: "Adwaita", package: "adwaita-swift"),
                 .product(name: "ChordProviderCore", package: "ChordProviderCore"),
                 "CSourceView"
             ],
@@ -56,7 +56,7 @@ let package = Package(
                 "SourceView",
                 "ChordProviderMIDI",
                 //"CFluidSynth",
-                .product(name: "Adwaita", package: "adwaita-swift-gnome-50"),
+                .product(name: "Adwaita", package: "adwaita-swift"),
                 .product(name: "ChordProviderCore", package: "ChordProviderCore")
             ],
             resources: [

--- a/ChordProviderGnome/Sources/ChordProvider/Extensions/AnyView+extensions.swift
+++ b/ChordProviderGnome/Sources/ChordProvider/Extensions/AnyView+extensions.swift
@@ -36,7 +36,7 @@ extension AnyView {
     public func vertical() -> AnyView {
         inspect { storage, updateProperties in
             if updateProperties {
-                gtk_orientable_set_orientation(storage.opaquePointer, GTK_ORIENTATION_VERTICAL)
+                gtk_orientable_set_orientation(storage.opaquePointer, .GTK_ORIENTATION_VERTICAL)
             }
         }
     }
@@ -46,7 +46,7 @@ extension AnyView {
     public func horizontal() -> AnyView {
         inspect { storage, updateProperties in
             if updateProperties {
-                gtk_orientable_set_orientation(storage.opaquePointer, GTK_ORIENTATION_HORIZONTAL)
+                gtk_orientable_set_orientation(storage.opaquePointer, .GTK_ORIENTATION_HORIZONTAL)
             }
         }
     }

--- a/ChordProviderGnome/Sources/ChordProvider/Widgets/Widgets+Columns.swift
+++ b/ChordProviderGnome/Sources/ChordProvider/Widgets/Widgets+Columns.swift
@@ -31,7 +31,7 @@ extension Widgets {
         /// - Returns: The view storage.
         public func container<Data>(data: WidgetData, type: Data.Type) -> ViewStorage where Data: ViewRenderData {
             let storage = ViewStorage(adw_wrap_box_new()?.opaque())
-            gtk_orientable_set_orientation(storage.opaquePointer, GTK_ORIENTATION_VERTICAL)
+            gtk_orientable_set_orientation(storage.opaquePointer, .GTK_ORIENTATION_VERTICAL)
             adw_wrap_box_set_line_spacing(storage.opaquePointer, 20)
             return storage
         }


### PR DESCRIPTION
Hello :) wow, this app is truly looking great, and definitely the most complex piece of software written with Adwaita for Swift so far. I absolutely love the themes and the integrated MIDI player, as well as the text editor with search and autocompletion.

As announced, I will continue working on Adwaita for Swift (your project certainly helped me rediscover this "spark"). However, I decided to move the development to Codeberg instead of my own instance. In general, SPM is still able to fetch the libraries from the same URL thanks to redirects, however, not so for repos that weren't in the Aparoksha/WinUI for Swift organizations (or my private profile).

This commit fixes this problem as well as errors due to me starting the transition to a more "Swifty" way of interacting with the C library in CAdw. Sorry for any inconvenience :/

Wish you the best!

David